### PR TITLE
Setup automatic garbage collection for NixOS

### DIFF
--- a/systems/nixos/china/configuration.nix
+++ b/systems/nixos/china/configuration.nix
@@ -1,11 +1,14 @@
 # Edit this configuration file to define what should be installed on
 # your system.  Help is available in the configuration.nix(5) man page
-# and in the NixOS manual (accessible by running ‘nixos-help’).
+# and in the NixOS manual (accessible by running 'nixos-help').
 {
   pkgs,
   inputs,
   ...
 }: {
+  # Aggressive garbage collection for space-constrained 125GB drive
+  nix.gc.options = "--delete-older-than 7d";
+
   imports = [
     inputs.vpnconfinement.nixosModules.default
     ./hardware-configuration.nix

--- a/systems/nixos/configuration.nix
+++ b/systems/nixos/configuration.nix
@@ -83,6 +83,17 @@
     };
   };
 
+  # Automatic garbage collection - conservative defaults (14 days)
+  # China overrides these with more aggressive settings
+  nix.gc = {
+    automatic = true;
+    dates = "daily";
+    options = "--delete-older-than 14d";
+  };
+
+  # Deduplicate identical files in the store using hardlinks
+  nix.optimise.automatic = true;
+
   nix.settings.experimental-features = "nix-command flakes";
   nix.settings.substituters = [
     "http://jacob-china:5000/main" # Self-hosted Attic cache (via Tailscale)


### PR DESCRIPTION
Add daily nix garbage collection with store optimization:
- Conservative 14-day retention for most systems
- Aggressive 7-day retention for china (125GB drive constraint)